### PR TITLE
Model rework

### DIFF
--- a/app/controllers/stats_controller.rb
+++ b/app/controllers/stats_controller.rb
@@ -73,6 +73,8 @@ class StatsController < ApplicationController
 
     if @session.present?
       @last_session_duration = @session.end_time - @session.start_time
+      @total_time = 0
+      @ranking = 0
 
       @sessions_within_timeframe.each_with_index do |session, index|
           if @user == session.user

--- a/app/controllers/stats_controller.rb
+++ b/app/controllers/stats_controller.rb
@@ -69,7 +69,7 @@ class StatsController < ApplicationController
 
     @user_sessions = UserSession.with_user(@user).order("-created_at")
     @session = @user_sessions.first
-    @longest_session = @user_sessions.longest_session.first.longest_session
+    @longest_session = @user_sessions.with_longest_session.first.longest_session
 
     if @session.present?
       @last_session_duration = @session.end_time - @session.start_time

--- a/app/helpers/stats_helper.rb
+++ b/app/helpers/stats_helper.rb
@@ -103,7 +103,7 @@ module StatsHelper
           seconds += (s.end_time - s.start_time)
         end
 
-        if @session.end_time > Time.zone.now
+        if @session.present? && @session.end_time > Time.zone.now
           seconds - (@session.end_time - Time.zone.now)
         else
           seconds

--- a/app/models/user_session.rb
+++ b/app/models/user_session.rb
@@ -13,7 +13,12 @@
 class UserSession < ActiveRecord::Base
   scope :with_user, -> (user) { where(user_id: user) }
   scope :active, -> { where("end_time > ?", DateTime.now) }
-  scope :time_between, -> (from=0, to='2099-01-01') {where('start_time >= ? and end_time <= ?', from, to).select('*, SUM(TIMESTAMPDIFF(SECOND, START_TIME, END_TIME)) as total_time').group(:user_id).order('total_time DESC')}
-  scope :longest_session, -> {select('*, MAX(TIMESTAMPDIFF(SECOND, START_TIME, END_TIME)) as longest_session')}
+  scope :time_between, -> (from=0, to='2099-01-01') {
+    where('start_time >= ? and end_time <= ?', from, to)
+      .select('user_id, SUM(TIMESTAMPDIFF(SECOND, START_TIME, END_TIME)) as total_time')
+      .group(:user_id)
+      .order('total_time DESC')
+  }
+  scope :with_longest_session, -> {select('user_id, MAX(TIMESTAMPDIFF(SECOND, START_TIME, END_TIME)) as longest_session')}
   belongs_to :user
 end


### PR DESCRIPTION
Fixes data related bugs.

MySQL 5.7.5 and later versions will no longer complain about our query and the `My stats` page will no longer crash if the Hubb has not been visited within the current time period.